### PR TITLE
Bug fix in SOAP and ROS. 

### DIFF
--- a/interface/forms/ros/templates/ros/general_new.html
+++ b/interface/forms/ros/templates/ros/general_new.html
@@ -605,7 +605,7 @@ a {
 </tr>
 <tr>
 <td>
-	<input type="submit" name="Submit" value={php} xl('Save Form','e','"','"');> {/php}
+	<input type="submit" name="Submit" value={php} xl('Save Form','e','"','"'); {/php}>
 </td>
 <td>
 	<a href="{$DONT_SAVE_LINK}" class="link" onclick="top.restoreSession()">[{php} xl("Don't Save","e"); {/php}]</a>

--- a/interface/forms/soap/templates/general_new.html
+++ b/interface/forms/soap/templates/general_new.html
@@ -67,7 +67,7 @@ a {
 		</td>
 	</tr>
 	<tr>
-		<td><input type="submit" name="Submit" value={php} xl('Save Form','e','"','"');> {/php}</td>
+		<td><input type="submit" name="Submit" value={php} xl('Save Form','e','"','"'); {/php}></td>
     <td><a href="{$DONT_SAVE_LINK}" class="link" onclick="top.restoreSession()">[{php} xl("Don't Save","e"); {/php}]</a></td>
 	</tr>
 </table>


### PR DESCRIPTION
Closing HTML tag was being interpreted as PHP causing syntax error in these two forms. 